### PR TITLE
Add unit tests for misc helpers

### DIFF
--- a/src/tests/unit/utils/getCoreModulesConfig.test.ts
+++ b/src/tests/unit/utils/getCoreModulesConfig.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const mockModules = (entries: Array<[string, { id: string; version: string; tags: string[] }]>) => {
+	vi.doMock('@/modules', () => ({
+		default: new Map(entries)
+	}))
+}
+
+describe('getCoreModulesConfig', () => {
+	afterEach(() => {
+		vi.resetModules()
+		vi.restoreAllMocks()
+	})
+
+	it('returns configuration only for modules tagged with "core"', async () => {
+		mockModules([
+			['core1', { id: 'core1', version: '1.0.0', tags: ['core'] }],
+			['non', { id: 'non', version: '1.0.0', tags: ['other'] }],
+			['core2', { id: 'core2', version: '2.0.0', tags: ['extra', 'core'] }]
+		])
+
+		const { getCoreModulesConfig } = await import('@/utils/helpers/getCoreModulesConfig')
+		const result = getCoreModulesConfig()
+		expect(result).toEqual({
+			core1: { config: {}, version: '1.0.0' },
+			core2: { config: {}, version: '2.0.0' }
+		})
+	})
+
+	it('returns empty object when no core modules are present', async () => {
+		mockModules([['mod', { id: 'mod', version: '1.0.0', tags: ['notcore'] }]])
+		const { getCoreModulesConfig } = await import('@/utils/helpers/getCoreModulesConfig')
+		expect(getCoreModulesConfig()).toEqual({})
+	})
+})

--- a/src/tests/unit/utils/getPatches.test.ts
+++ b/src/tests/unit/utils/getPatches.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { getPatches } from '@/utils/helpers/getPatches'
+import type { FatePatch } from '@/types'
+
+function makePatch(version: string): FatePatch {
+	return {
+		version,
+		note: '',
+		incompatible: false,
+		action: async () => {}
+	}
+}
+
+describe('getPatches', () => {
+	it('returns empty array when no patches are newer than fromVersion', () => {
+		const patches = [makePatch('1.0.0'), makePatch('1.1.0')]
+		expect(getPatches(patches, '1.1.0')).toEqual([])
+	})
+
+	it('filters and sorts patches greater than fromVersion', () => {
+		const patches = [makePatch('1.2.0'), makePatch('1.0.0'), makePatch('1.1.0')]
+		const result = getPatches(patches, '0.9.0')
+		expect(result.map(p => p.version)).toEqual(['1.0.0', '1.1.0', '1.2.0'])
+	})
+
+	it('ignores patches below or equal to fromVersion', () => {
+		const patches = [makePatch('1.0.0'), makePatch('1.2.0')]
+		const result = getPatches(patches, '1.1.0')
+		expect(result.map(p => p.version)).toEqual(['1.2.0'])
+	})
+})

--- a/src/tests/unit/utils/randomUtils.test.ts
+++ b/src/tests/unit/utils/randomUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { randomRange, randomArrayValue } from '@/utils/helpers/random'
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe('randomRange', () => {
+	it('returns the minimum value when Math.random() is 0', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0)
+		expect(randomRange(5, 10)).toBe(5)
+	})
+
+	it('returns the maximum value when Math.random() is close to 1', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0.9999)
+		expect(randomRange(5, 10)).toBe(10)
+	})
+
+	it('works with negative ranges', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0.5)
+		expect(randomRange(-5, -2)).toBe(-3)
+	})
+})
+
+describe('randomArrayValue', () => {
+	it('returns undefined for an empty array', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0)
+		expect(randomArrayValue([])).toBeUndefined()
+	})
+
+	it('returns the first element when Math.random() is 0', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0)
+		expect(randomArrayValue([1, 2, 3])).toBe(1)
+	})
+
+	it('returns the last element when Math.random() is close to 1', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0.9999)
+		expect(randomArrayValue([1, 2, 3])).toBe(3)
+	})
+
+	it('returns the only element in a single-item array', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0.3)
+		expect(randomArrayValue(['a'])).toBe('a')
+	})
+})


### PR DESCRIPTION
## Summary
- add tests for randomRange and randomArrayValue helpers
- test getPatches helper
- test getCoreModulesConfig

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6872f7f9ede4832ca0626b116367dacf